### PR TITLE
Handle POST requests from webhook

### DIFF
--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -50,6 +50,12 @@
       <version>6.8.0.202311291450-r</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20230618</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -56,12 +56,6 @@
       <version>20230618</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-      <version>12.0.6</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -56,6 +56,12 @@
       <version>20230618</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+      <version>12.0.6</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -11,6 +11,9 @@ import org.eclipse.jetty.server.Server;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.json.JSONObject;
+
+import org.json.*;
 
 
 /** 

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -72,7 +72,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
 
     /**
      * Retreive JSON object from POST request
-     * @param request the incoming request with data
+     * @param reader a BufferedReader with the data from the incoming request
      * @return the JSON object containing data from request.
      */
     public JSONObject readPostData(BufferedReader reader){

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -39,6 +39,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
                     buffer.append(System.lineSeparator());
                 }
                 String data = buffer.toString();
+                JSONObject jsonObj = new JSONObject(data);
                 
                 break;
             case "GET":

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -44,7 +44,9 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 ref = ref.substring(ref.lastIndexOf("/")+1);
                 String commitId = jsonObj.getJSONObject("head_commit").getString("id");
                 String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
+                String print = "branch: " + ref + " commit id: " + commitId + " clone url: " + cloneUrl;
 
+                response.getWriter().println(print);
                 
                 break;
             case "GET":

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -36,7 +36,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
                     BufferedReader reader = request.getReader();
                     JSONObject jsonObj = readPostData(reader);
                     String ref = jsonObj.getString("ref");
-                    ref = ref.substring(ref.lastIndexOf("/")+1);
+                    ref = ref.substring(ref.lastIndexOf("heads/")+1);
                     String commitId = jsonObj.getJSONObject("head_commit").getString("id");
                     String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
                     String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -31,15 +31,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         System.out.println(target);
         switch (request.getMethod()) {
             case "POST":
-                StringBuilder buffer = new StringBuilder();
-                BufferedReader reader = request.getReader();
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    buffer.append(line);
-                    buffer.append(System.lineSeparator());
-                }
-                String data = buffer.toString();
-                JSONObject jsonObj = new JSONObject(data);
+                JSONObject jsonObj = readPostData(request);
                 String ref = jsonObj.getString("ref");
                 ref = ref.substring(ref.lastIndexOf("/")+1);
                 String commitId = jsonObj.getJSONObject("head_commit").getString("id");
@@ -68,6 +60,25 @@ public class ContinuousIntegrationServer extends AbstractHandler
         // 2nd compile the code
 
         response.getWriter().println("CI job done");
+    }
+
+    public JSONObject readPostData(HttpServletRequest request){
+        StringBuilder buffer = new StringBuilder();
+        BufferedReader reader;
+        try {
+            reader = request.getReader();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line);
+                buffer.append(System.lineSeparator());
+            }
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+        String data = buffer.toString();
+        JSONObject jsonObj = new JSONObject(data);
+        return jsonObj;
     }
  
     // used to start the CI server in command line

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -37,6 +37,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
                     RepositoryInfo repo = readPostData(reader);
                     String print = "branch: " + repo.ref + " commit id: " + repo.commitId + " clone url: " + repo.cloneUrl;
                     response.getWriter().println(print);
+                    RepositoryTester repositoryTester = new RepositoryTester(repo);
+                    repositoryTester.runTests();
 
                 } catch (IOException e) {
                     // TODO Auto-generated catch block
@@ -93,11 +95,13 @@ public class ContinuousIntegrationServer extends AbstractHandler
     // used to start the CI server in command line
     public static void main(String[] args) throws Exception
     {
-        String owner = "alexarne";
-        String repositoryName = "DD2480-CI";
-        String SHA = "qowdpinqwdoin";
-        String branch = "master";
-        RepositoryTester repositoryTester = new RepositoryTester(owner, repositoryName, SHA, branch);
+        String testOwner = "alexarne";
+        String testRepositoryName = "DD2480-CI";
+        String testSHA = "qowdpinqwdoin";
+        String testBranch = "main";
+        String testCloneUrl = "https://github.com/alexarne/DD2480-CI.git";
+        RepositoryInfo testRepo = new RepositoryInfo(testBranch, testSHA, testCloneUrl, testOwner, testRepositoryName);
+        RepositoryTester repositoryTester = new RepositoryTester(testRepo);
         repositoryTester.runTests();
         Server server = new Server(Config.PORT);
         server.setHandler(new ContinuousIntegrationServer()); 

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -62,6 +62,11 @@ public class ContinuousIntegrationServer extends AbstractHandler
         response.getWriter().println("CI job done");
     }
 
+    /**
+     * Retreive JSON object from POST request
+     * @param request the incoming request with data
+     * @return the JSON object containing data from request.
+     */
     public JSONObject readPostData(HttpServletRequest request){
         StringBuilder buffer = new StringBuilder();
         BufferedReader reader;

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -28,19 +28,27 @@ public class ContinuousIntegrationServer extends AbstractHandler
                        HttpServletResponse response) 
         throws IOException, ServletException
     {
+        
         System.out.println(target);
         switch (request.getMethod()) {
             case "POST":
-                JSONObject jsonObj = readPostData(request);
-                String ref = jsonObj.getString("ref");
-                ref = ref.substring(ref.lastIndexOf("/")+1);
-                String commitId = jsonObj.getJSONObject("head_commit").getString("id");
-                String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
-                String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
+                try{
+                    BufferedReader reader = request.getReader();
+                    JSONObject jsonObj = readPostData(reader);
+                    String ref = jsonObj.getString("ref");
+                    ref = ref.substring(ref.lastIndexOf("/")+1);
+                    String commitId = jsonObj.getJSONObject("head_commit").getString("id");
+                    String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
+                    String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
 
-                String print = "branch: " + ref + " commit id: " + commitId + " clone url: " + cloneUrl;
+                    String print = "branch: " + ref + " commit id: " + commitId + " clone url: " + cloneUrl;
 
-                response.getWriter().println(print);
+                    response.getWriter().println(print);
+                } catch (IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+
                 
                 break;
             case "GET":
@@ -67,11 +75,9 @@ public class ContinuousIntegrationServer extends AbstractHandler
      * @param request the incoming request with data
      * @return the JSON object containing data from request.
      */
-    public JSONObject readPostData(HttpServletRequest request){
+    public JSONObject readPostData(BufferedReader reader){
         StringBuilder buffer = new StringBuilder();
-        BufferedReader reader;
         try {
-            reader = request.getReader();
             String line;
             while ((line = reader.readLine()) != null) {
                 buffer.append(line);

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -43,6 +43,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 String ref = jsonObj.getString("ref");
                 ref = ref.substring(ref.lastIndexOf("/")+1);
                 String commitId = jsonObj.getJSONObject("head_commit").getString("id");
+                String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
 
                 
                 break;

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -40,6 +40,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 }
                 String data = buffer.toString();
                 JSONObject jsonObj = new JSONObject(data);
+                String ref = jsonObj.getString("ref");
+                ref = ref.substring(ref.lastIndexOf("/")+1);
                 
                 break;
             case "GET":

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -42,6 +42,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 JSONObject jsonObj = new JSONObject(data);
                 String ref = jsonObj.getString("ref");
                 ref = ref.substring(ref.lastIndexOf("/")+1);
+                String commitId = jsonObj.getJSONObject("head_commit").getString("id");
+
                 
                 break;
             case "GET":

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -86,7 +86,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
         String commitId = jsonObj.getJSONObject("head_commit").getString("id");
         String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
         String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
-        return new RepositoryInfo(ref, commitId, cloneUrl, owner);
+        String name = jsonObj.getJSONObject("repository").getString(name);
+        return new RepositoryInfo(ref, commitId, cloneUrl, owner, name);
     }
  
     // used to start the CI server in command line

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -3,7 +3,8 @@ package com.group21.ci;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
- 
+
+import java.io.BufferedReader;
 import java.io.IOException;
  
 import org.eclipse.jetty.server.Server;
@@ -27,6 +28,14 @@ public class ContinuousIntegrationServer extends AbstractHandler
         System.out.println(target);
         switch (request.getMethod()) {
             case "POST":
+                StringBuilder buffer = new StringBuilder();
+                BufferedReader reader = request.getReader();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    buffer.append(line);
+                    buffer.append(System.lineSeparator());
+                }
+                String data = buffer.toString();
                 
                 break;
             case "GET":

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -44,6 +44,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 ref = ref.substring(ref.lastIndexOf("/")+1);
                 String commitId = jsonObj.getJSONObject("head_commit").getString("id");
                 String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
+                String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
+
                 String print = "branch: " + ref + " commit id: " + commitId + " clone url: " + cloneUrl;
 
                 response.getWriter().println(print);

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -82,12 +82,11 @@ public class ContinuousIntegrationServer extends AbstractHandler
         String data = buffer.toString();
         JSONObject jsonObj = new JSONObject(data);
         String ref = jsonObj.getString("ref");
-        ref = ref.substring(ref.lastIndexOf("heads/")+1);
+        ref = ref.substring(ref.lastIndexOf("heads/")+6);
         String commitId = jsonObj.getJSONObject("head_commit").getString("id");
         String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
         String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
-        RepositoryInfo repo = new RepositoryInfo(ref, commitId, cloneUrl, owner);
-        return repo;
+        return new RepositoryInfo(ref, commitId, cloneUrl, owner);
     }
  
     // used to start the CI server in command line

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -86,7 +86,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         String commitId = jsonObj.getJSONObject("head_commit").getString("id");
         String cloneUrl = jsonObj.getJSONObject("repository").getString("clone_url");
         String owner = jsonObj.getJSONObject("repository").getJSONObject("owner").getString("name");
-        String name = jsonObj.getJSONObject("repository").getString(name);
+        String name = jsonObj.getJSONObject("repository").getString("name");
         return new RepositoryInfo(ref, commitId, cloneUrl, owner, name);
     }
  

--- a/ci/src/main/java/com/group21/ci/RepositoryInfo.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryInfo.java
@@ -5,12 +5,14 @@ public class RepositoryInfo {
     String commitId;
     String cloneUrl;
     String owner;
+    String name;
 
-    public RepositoryInfo(String ref, String commitId, String cloneUrl, String owner){
+    public RepositoryInfo(String ref, String commitId, String cloneUrl, String owner, String name){
         this.ref = ref;
         this.commitId = commitId;
         this.cloneUrl = cloneUrl;
         this.owner = owner;
+        this.name = name;
     }
     
 }

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -15,12 +15,12 @@ public class RepositoryTester {
     private String owner;
     private String repositoryName;
 
-    public RepositoryTester(String owner, String repositoryName, String SHA, String branch) {
-        this.owner = owner;
-        this.repositoryName = repositoryName;
-        this.URL = "https://github.com/" + owner + "/" + repositoryName;
-        this.SHA = SHA;
-        this.branch = branch;
+    public RepositoryTester(RepositoryInfo repo) {
+        this.owner = repo.owner;
+        //this.repositoryName = repositoryName;
+        this.URL = repo.cloneUrl;
+        this.SHA = repo.commitId;
+        this.branch = repo.ref;
     }
     
     public void runTests() {

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -17,7 +17,7 @@ public class RepositoryTester {
 
     public RepositoryTester(RepositoryInfo repo) {
         this.owner = repo.owner;
-        //this.repositoryName = repositoryName;
+        this.repositoryName = repo.name;
         this.URL = repo.cloneUrl;
         this.SHA = repo.commitId;
         this.branch = repo.ref;

--- a/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
+++ b/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
@@ -8,6 +8,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -72,5 +73,55 @@ public class ContinuousIntegrationServerTest
         RepositoryInfo repo = server.readPostData(reader);
         RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
         assertEquals(trueRepo.ref, repo.ref);
+    }
+
+    @Test
+    public void readPostDataReturnsCorrectCommitId(){
+        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
+        String gitHubPayload = "{\"ref\":\"refs/heads/main\", \"repository\": {\r\n" + //
+                        "    \"id\": 754107114,\r\n" + //
+                        "    \"node_id\": \"R_kgDOLPLC6g\",\r\n" + //
+                        "    \"name\": \"DD2480-CI-TEST\",\r\n" + //
+                        "    \"full_name\": \"haaker1/DD2480-CI-TEST\",\r\n" + //
+                        "    \"private\": true,\r\n" + //
+                        "    \"owner\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"104437718+haaker1@users.noreply.github.com\",\r\n" + //
+                        "      \"login\": \"haaker1\",\r\n" + //
+                        "      \"id\": 104437718,\r\n" + //
+                        "      \"node_id\": \"U_kgDOBjmX1g\",\r\n" + //
+                        "      \"avatar_url\": \"https://avatars.githubusercontent.com/u/104437718?v=4\",\r\n" + //
+                        "      \"gravatar_id\": \"\",\r\n" + //
+                        "      \"url\": \"https://api.github.com/users/haaker1\",\r\n" + //
+                        "      \"html_url\": \"https://github.com/haaker1\",\r\n" + //
+                        "      \"followers_url\": \"https://api.github.com/users/haaker1/followers\",\r\n" + //
+                        "      \"following_url\": \"https://api.github.com/users/haaker1/following{/other_user}\",\r\n" + //
+                        "      \"gists_url\": \"https://api.github.com/users/haaker1/gists{/gist_id}\",\r\n" + //
+                        "      \"starred_url\": \"https://api.github.com/users/haaker1/starred{/owner}{/repo}\",\r\n" + //
+                        "      \"subscriptions_url\": \"https://api.github.com/users/haaker1/subscriptions\",\r\n" + //
+                        "      \"organizations_url\": \"https://api.github.com/users/haaker1/orgs\",\r\n" + //
+                        "      \"repos_url\": \"https://api.github.com/users/haaker1/repos\",\r\n" + //
+                        "      \"events_url\": \"https://api.github.com/users/haaker1/events{/privacy}\",\r\n" + //
+                        "      \"received_events_url\": \"https://api.github.com/users/haaker1/received_events\",\r\n" + //
+                        "      \"type\": \"User\",\r\n" + //
+                        "      \"site_admin\": false\r\n" + //
+                        "    },     \"clone_url\": \"https://github.com/haaker1/DD2480-CI-TEST.git\",\r\n},\"head_commit\": {\r\n" + //
+                        "    \"id\": \"944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"tree_id\": \"4bfe6e16e9558c2d3319ba42c196f7e3df937c72\",\r\n" + //
+                        "    \"distinct\": true,\r\n" + //
+                        "    \"message\": \"saker\",\r\n" + //
+                        "    \"timestamp\": \"2024-02-07T15:15:27+01:00\",\r\n" + //
+                        "    \"url\": \"https://github.com/haaker1/DD2480-CI-TEST/commit/944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"author\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"haaker.anne@gmail.com\",\r\n" + //
+                        "      \"username\": \"haaker1\"\r\n" + //
+                        "    },\r\n" + //
+                        "  }}";
+        Reader inputString = new StringReader(gitHubPayload);
+        BufferedReader reader = new BufferedReader(inputString);
+        RepositoryInfo repo = server.readPostData(reader);
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        assertEquals(trueRepo.commitId, repo.commitId);
     }
 }

--- a/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
+++ b/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
@@ -72,6 +72,9 @@ public class ContinuousIntegrationServerTest
         assertTrue( true );
     }
 
+    /**
+     * Assert that the branch name extracted from the payload in readPostData is correct.
+     */
     @Test
     public void readPostDataReturnsCorrectRepoBranch(){
         Reader inputString = new StringReader(gitHubPayload);
@@ -81,13 +84,27 @@ public class ContinuousIntegrationServerTest
         assertEquals(trueRepo.ref, repo.ref);
     }
 
+    /**
+     * Assert that the commit id (SHA) extracted from the payload in readPostData is correct.
+     */
     @Test
     public void readPostDataReturnsCorrectCommitId(){
-        
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);
         RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
         assertEquals(trueRepo.commitId, repo.commitId);
+    }
+
+    /**
+     * Assert that the clone URL extracted from the payload in readPostData is correct.
+     */
+    @Test
+    public void readPostDataReturnsCorrectCloneUrl(){
+        Reader inputString = new StringReader(gitHubPayload);
+        BufferedReader reader = new BufferedReader(inputString);
+        RepositoryInfo repo = server.readPostData(reader);
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        assertEquals(trueRepo.cloneUrl, repo.cloneUrl);
     }
 }

--- a/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
+++ b/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
@@ -16,6 +16,53 @@ import org.junit.Test;
  */
 public class ContinuousIntegrationServerTest 
 {
+    ContinuousIntegrationServer server;
+    String gitHubPayload;
+
+    @Before
+    public void setUp(){
+        server = new ContinuousIntegrationServer();
+        gitHubPayload = "{\"ref\":\"refs/heads/main\", \"repository\": {\r\n" + //
+                        "    \"id\": 754107114,\r\n" + //
+                        "    \"node_id\": \"R_kgDOLPLC6g\",\r\n" + //
+                        "    \"name\": \"DD2480-CI-TEST\",\r\n" + //
+                        "    \"full_name\": \"haaker1/DD2480-CI-TEST\",\r\n" + //
+                        "    \"private\": true,\r\n" + //
+                        "    \"owner\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"104437718+haaker1@users.noreply.github.com\",\r\n" + //
+                        "      \"login\": \"haaker1\",\r\n" + //
+                        "      \"id\": 104437718,\r\n" + //
+                        "      \"node_id\": \"U_kgDOBjmX1g\",\r\n" + //
+                        "      \"avatar_url\": \"https://avatars.githubusercontent.com/u/104437718?v=4\",\r\n" + //
+                        "      \"gravatar_id\": \"\",\r\n" + //
+                        "      \"url\": \"https://api.github.com/users/haaker1\",\r\n" + //
+                        "      \"html_url\": \"https://github.com/haaker1\",\r\n" + //
+                        "      \"followers_url\": \"https://api.github.com/users/haaker1/followers\",\r\n" + //
+                        "      \"following_url\": \"https://api.github.com/users/haaker1/following{/other_user}\",\r\n" + //
+                        "      \"gists_url\": \"https://api.github.com/users/haaker1/gists{/gist_id}\",\r\n" + //
+                        "      \"starred_url\": \"https://api.github.com/users/haaker1/starred{/owner}{/repo}\",\r\n" + //
+                        "      \"subscriptions_url\": \"https://api.github.com/users/haaker1/subscriptions\",\r\n" + //
+                        "      \"organizations_url\": \"https://api.github.com/users/haaker1/orgs\",\r\n" + //
+                        "      \"repos_url\": \"https://api.github.com/users/haaker1/repos\",\r\n" + //
+                        "      \"events_url\": \"https://api.github.com/users/haaker1/events{/privacy}\",\r\n" + //
+                        "      \"received_events_url\": \"https://api.github.com/users/haaker1/received_events\",\r\n" + //
+                        "      \"type\": \"User\",\r\n" + //
+                        "      \"site_admin\": false\r\n" + //
+                        "    },     \"clone_url\": \"https://github.com/haaker1/DD2480-CI-TEST.git\",\r\n},\"head_commit\": {\r\n" + //
+                        "    \"id\": \"944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"tree_id\": \"4bfe6e16e9558c2d3319ba42c196f7e3df937c72\",\r\n" + //
+                        "    \"distinct\": true,\r\n" + //
+                        "    \"message\": \"saker\",\r\n" + //
+                        "    \"timestamp\": \"2024-02-07T15:15:27+01:00\",\r\n" + //
+                        "    \"url\": \"https://github.com/haaker1/DD2480-CI-TEST/commit/944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"author\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"haaker.anne@gmail.com\",\r\n" + //
+                        "      \"username\": \"haaker1\"\r\n" + //
+                        "    },\r\n" + //
+                        "  }}";
+    }
     /**
      * Rigorous Test :-)
      */
@@ -27,47 +74,6 @@ public class ContinuousIntegrationServerTest
 
     @Test
     public void readPostDataReturnsCorrectRepoBranch(){
-        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
-        String gitHubPayload = "{\"ref\":\"refs/heads/main\", \"repository\": {\r\n" + //
-                        "    \"id\": 754107114,\r\n" + //
-                        "    \"node_id\": \"R_kgDOLPLC6g\",\r\n" + //
-                        "    \"name\": \"DD2480-CI-TEST\",\r\n" + //
-                        "    \"full_name\": \"haaker1/DD2480-CI-TEST\",\r\n" + //
-                        "    \"private\": true,\r\n" + //
-                        "    \"owner\": {\r\n" + //
-                        "      \"name\": \"haaker1\",\r\n" + //
-                        "      \"email\": \"104437718+haaker1@users.noreply.github.com\",\r\n" + //
-                        "      \"login\": \"haaker1\",\r\n" + //
-                        "      \"id\": 104437718,\r\n" + //
-                        "      \"node_id\": \"U_kgDOBjmX1g\",\r\n" + //
-                        "      \"avatar_url\": \"https://avatars.githubusercontent.com/u/104437718?v=4\",\r\n" + //
-                        "      \"gravatar_id\": \"\",\r\n" + //
-                        "      \"url\": \"https://api.github.com/users/haaker1\",\r\n" + //
-                        "      \"html_url\": \"https://github.com/haaker1\",\r\n" + //
-                        "      \"followers_url\": \"https://api.github.com/users/haaker1/followers\",\r\n" + //
-                        "      \"following_url\": \"https://api.github.com/users/haaker1/following{/other_user}\",\r\n" + //
-                        "      \"gists_url\": \"https://api.github.com/users/haaker1/gists{/gist_id}\",\r\n" + //
-                        "      \"starred_url\": \"https://api.github.com/users/haaker1/starred{/owner}{/repo}\",\r\n" + //
-                        "      \"subscriptions_url\": \"https://api.github.com/users/haaker1/subscriptions\",\r\n" + //
-                        "      \"organizations_url\": \"https://api.github.com/users/haaker1/orgs\",\r\n" + //
-                        "      \"repos_url\": \"https://api.github.com/users/haaker1/repos\",\r\n" + //
-                        "      \"events_url\": \"https://api.github.com/users/haaker1/events{/privacy}\",\r\n" + //
-                        "      \"received_events_url\": \"https://api.github.com/users/haaker1/received_events\",\r\n" + //
-                        "      \"type\": \"User\",\r\n" + //
-                        "      \"site_admin\": false\r\n" + //
-                        "    },     \"clone_url\": \"https://github.com/haaker1/DD2480-CI-TEST.git\",\r\n},\"head_commit\": {\r\n" + //
-                        "    \"id\": \"944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
-                        "    \"tree_id\": \"4bfe6e16e9558c2d3319ba42c196f7e3df937c72\",\r\n" + //
-                        "    \"distinct\": true,\r\n" + //
-                        "    \"message\": \"saker\",\r\n" + //
-                        "    \"timestamp\": \"2024-02-07T15:15:27+01:00\",\r\n" + //
-                        "    \"url\": \"https://github.com/haaker1/DD2480-CI-TEST/commit/944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
-                        "    \"author\": {\r\n" + //
-                        "      \"name\": \"haaker1\",\r\n" + //
-                        "      \"email\": \"haaker.anne@gmail.com\",\r\n" + //
-                        "      \"username\": \"haaker1\"\r\n" + //
-                        "    },\r\n" + //
-                        "  }}";
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);
@@ -77,47 +83,7 @@ public class ContinuousIntegrationServerTest
 
     @Test
     public void readPostDataReturnsCorrectCommitId(){
-        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
-        String gitHubPayload = "{\"ref\":\"refs/heads/main\", \"repository\": {\r\n" + //
-                        "    \"id\": 754107114,\r\n" + //
-                        "    \"node_id\": \"R_kgDOLPLC6g\",\r\n" + //
-                        "    \"name\": \"DD2480-CI-TEST\",\r\n" + //
-                        "    \"full_name\": \"haaker1/DD2480-CI-TEST\",\r\n" + //
-                        "    \"private\": true,\r\n" + //
-                        "    \"owner\": {\r\n" + //
-                        "      \"name\": \"haaker1\",\r\n" + //
-                        "      \"email\": \"104437718+haaker1@users.noreply.github.com\",\r\n" + //
-                        "      \"login\": \"haaker1\",\r\n" + //
-                        "      \"id\": 104437718,\r\n" + //
-                        "      \"node_id\": \"U_kgDOBjmX1g\",\r\n" + //
-                        "      \"avatar_url\": \"https://avatars.githubusercontent.com/u/104437718?v=4\",\r\n" + //
-                        "      \"gravatar_id\": \"\",\r\n" + //
-                        "      \"url\": \"https://api.github.com/users/haaker1\",\r\n" + //
-                        "      \"html_url\": \"https://github.com/haaker1\",\r\n" + //
-                        "      \"followers_url\": \"https://api.github.com/users/haaker1/followers\",\r\n" + //
-                        "      \"following_url\": \"https://api.github.com/users/haaker1/following{/other_user}\",\r\n" + //
-                        "      \"gists_url\": \"https://api.github.com/users/haaker1/gists{/gist_id}\",\r\n" + //
-                        "      \"starred_url\": \"https://api.github.com/users/haaker1/starred{/owner}{/repo}\",\r\n" + //
-                        "      \"subscriptions_url\": \"https://api.github.com/users/haaker1/subscriptions\",\r\n" + //
-                        "      \"organizations_url\": \"https://api.github.com/users/haaker1/orgs\",\r\n" + //
-                        "      \"repos_url\": \"https://api.github.com/users/haaker1/repos\",\r\n" + //
-                        "      \"events_url\": \"https://api.github.com/users/haaker1/events{/privacy}\",\r\n" + //
-                        "      \"received_events_url\": \"https://api.github.com/users/haaker1/received_events\",\r\n" + //
-                        "      \"type\": \"User\",\r\n" + //
-                        "      \"site_admin\": false\r\n" + //
-                        "    },     \"clone_url\": \"https://github.com/haaker1/DD2480-CI-TEST.git\",\r\n},\"head_commit\": {\r\n" + //
-                        "    \"id\": \"944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
-                        "    \"tree_id\": \"4bfe6e16e9558c2d3319ba42c196f7e3df937c72\",\r\n" + //
-                        "    \"distinct\": true,\r\n" + //
-                        "    \"message\": \"saker\",\r\n" + //
-                        "    \"timestamp\": \"2024-02-07T15:15:27+01:00\",\r\n" + //
-                        "    \"url\": \"https://github.com/haaker1/DD2480-CI-TEST/commit/944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
-                        "    \"author\": {\r\n" + //
-                        "      \"name\": \"haaker1\",\r\n" + //
-                        "      \"email\": \"haaker.anne@gmail.com\",\r\n" + //
-                        "      \"username\": \"haaker1\"\r\n" + //
-                        "    },\r\n" + //
-                        "  }}";
+        
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);

--- a/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
+++ b/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
@@ -1,7 +1,13 @@
 package com.group21.ci;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.json.JSONObject;
 import org.junit.Test;
 
 /**
@@ -16,5 +22,55 @@ public class ContinuousIntegrationServerTest
     public void shouldAnswerWithTrue()
     {
         assertTrue( true );
+    }
+
+    @Test
+    public void readPostDataReturnsCorrectRepoBranch(){
+        ContinuousIntegrationServer server = new ContinuousIntegrationServer();
+        String gitHubPayload = "{\"ref\":\"refs/heads/main\", \"repository\": {\r\n" + //
+                        "    \"id\": 754107114,\r\n" + //
+                        "    \"node_id\": \"R_kgDOLPLC6g\",\r\n" + //
+                        "    \"name\": \"DD2480-CI-TEST\",\r\n" + //
+                        "    \"full_name\": \"haaker1/DD2480-CI-TEST\",\r\n" + //
+                        "    \"private\": true,\r\n" + //
+                        "    \"owner\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"104437718+haaker1@users.noreply.github.com\",\r\n" + //
+                        "      \"login\": \"haaker1\",\r\n" + //
+                        "      \"id\": 104437718,\r\n" + //
+                        "      \"node_id\": \"U_kgDOBjmX1g\",\r\n" + //
+                        "      \"avatar_url\": \"https://avatars.githubusercontent.com/u/104437718?v=4\",\r\n" + //
+                        "      \"gravatar_id\": \"\",\r\n" + //
+                        "      \"url\": \"https://api.github.com/users/haaker1\",\r\n" + //
+                        "      \"html_url\": \"https://github.com/haaker1\",\r\n" + //
+                        "      \"followers_url\": \"https://api.github.com/users/haaker1/followers\",\r\n" + //
+                        "      \"following_url\": \"https://api.github.com/users/haaker1/following{/other_user}\",\r\n" + //
+                        "      \"gists_url\": \"https://api.github.com/users/haaker1/gists{/gist_id}\",\r\n" + //
+                        "      \"starred_url\": \"https://api.github.com/users/haaker1/starred{/owner}{/repo}\",\r\n" + //
+                        "      \"subscriptions_url\": \"https://api.github.com/users/haaker1/subscriptions\",\r\n" + //
+                        "      \"organizations_url\": \"https://api.github.com/users/haaker1/orgs\",\r\n" + //
+                        "      \"repos_url\": \"https://api.github.com/users/haaker1/repos\",\r\n" + //
+                        "      \"events_url\": \"https://api.github.com/users/haaker1/events{/privacy}\",\r\n" + //
+                        "      \"received_events_url\": \"https://api.github.com/users/haaker1/received_events\",\r\n" + //
+                        "      \"type\": \"User\",\r\n" + //
+                        "      \"site_admin\": false\r\n" + //
+                        "    },     \"clone_url\": \"https://github.com/haaker1/DD2480-CI-TEST.git\",\r\n},\"head_commit\": {\r\n" + //
+                        "    \"id\": \"944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"tree_id\": \"4bfe6e16e9558c2d3319ba42c196f7e3df937c72\",\r\n" + //
+                        "    \"distinct\": true,\r\n" + //
+                        "    \"message\": \"saker\",\r\n" + //
+                        "    \"timestamp\": \"2024-02-07T15:15:27+01:00\",\r\n" + //
+                        "    \"url\": \"https://github.com/haaker1/DD2480-CI-TEST/commit/944955a73f18f5cbfae6d66da4688e3d1badee04\",\r\n" + //
+                        "    \"author\": {\r\n" + //
+                        "      \"name\": \"haaker1\",\r\n" + //
+                        "      \"email\": \"haaker.anne@gmail.com\",\r\n" + //
+                        "      \"username\": \"haaker1\"\r\n" + //
+                        "    },\r\n" + //
+                        "  }}";
+        Reader inputString = new StringReader(gitHubPayload);
+        BufferedReader reader = new BufferedReader(inputString);
+        RepositoryInfo repo = server.readPostData(reader);
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        assertEquals(trueRepo.ref, repo.ref);
     }
 }

--- a/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
+++ b/ci/src/test/java/com/group21/ci/ContinuousIntegrationServerTest.java
@@ -80,7 +80,7 @@ public class ContinuousIntegrationServerTest
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);
-        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1", "DD2480-CI-TEST");
         assertEquals(trueRepo.ref, repo.ref);
     }
 
@@ -92,7 +92,7 @@ public class ContinuousIntegrationServerTest
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);
-        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1", "DD2480-CI-TEST");
         assertEquals(trueRepo.commitId, repo.commitId);
     }
 
@@ -104,7 +104,7 @@ public class ContinuousIntegrationServerTest
         Reader inputString = new StringReader(gitHubPayload);
         BufferedReader reader = new BufferedReader(inputString);
         RepositoryInfo repo = server.readPostData(reader);
-        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1");
+        RepositoryInfo trueRepo = new RepositoryInfo("main", "944955a73f18f5cbfae6d66da4688e3d1badee04", "https://github.com/haaker1/DD2480-CI-TEST.git", "haaker1", "DD2480-CI-TEST");
         assertEquals(trueRepo.cloneUrl, repo.cloneUrl);
     }
 }


### PR DESCRIPTION
Implement RepositoryInfo class to hold info about repo. Handle POST requests from webhook by creating RepositoryInfo object from payload from GitHub webhook and create new repositoryTester that runs the tests. Also implements some tests for readPostData() that extracts info from payload and creates RepositoryInfo obj.

Includes PR #25 

Closes #16 #22 