### PR TITLE
Refactor: Send status outside of RepositoryTester and include link to history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Custom rules for .gitignore
 ngrok
-#*.env
+*.env
 ci/repos/
 ci/history/
 ci/build_history/

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@ Any repository which implements this CI has to provide a `test.sh` script in the
 
 Clone this repository and have Maven installed. This repository is also configured with certain tests for testing the CI itself, which can be executed by `mvn test`.
 
-- To start the CI server, do the following in one terminal:
-
-  1. Create a copy of `config.env-default` and rename it to `config.env`
-  2. Add your [GitHub Token](https://github.com/settings/tokens) to `config.env` (When generating the token, make sure to select the "classic" variant and tick the `repo:status` box under "Select scopes")
-  3. Do `cd ci`
-  4. Run `mvn exec:java`
-
 - To make the local server externally visible using ngrok, do the following in a separate terminal:
 
   - Configure ngrok:
@@ -29,6 +22,14 @@ Clone this repository and have Maven installed. This repository is also configur
   - Run ngrok (in a separate terminal):
 
     1. `./ngrok http 8021`
+
+- To start the CI server, do the following in one terminal:
+
+  1. Create a copy of `config.env-default` and rename it to `config.env`
+  2. Add your [GitHub Token](https://github.com/settings/tokens) to `config.env` (When generating the token, make sure to select the "classic" variant and tick the `repo:status` box under "Select scopes")
+  3. Add the ngrok URL to `config.env`, such as `HISTORY_URL=http://XXXX-XX-XX-XX.ngrok-free.app`
+  4. Do `cd ci`
+  5. Run `mvn exec:java`
 
 - To link the CI:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Clone this repository and have Maven installed. This repository is also configur
 - To start the CI server, do the following in one terminal:
 
   1. Create a copy of `config.env-default` and rename it to `config.env`
-  2. Fill in the fields of `config.env`
+  2. Add your [GitHub Token](https://github.com/settings/tokens) to `config.env` (When generating the token, make sure to select the "classic" variant and tick the `repo:status` box under "Select scopes")
   3. Do `cd ci`
   4. Run `mvn exec:java`
 
@@ -30,4 +30,6 @@ Clone this repository and have Maven installed. This repository is also configur
 
     1. `./ngrok http 8021`
 
-- With the CI server running, add the public link as a Webhook to your GitHub repository and set the "Content type" to be `application/json`.
+- To link the CI:
+
+  - Add the public link from ngrok as a Webhook to your GitHub repository and set the "Content type" to be `application/json`.

--- a/ci/src/main/java/com/group21/ci/Config.java
+++ b/ci/src/main/java/com/group21/ci/Config.java
@@ -9,6 +9,12 @@ public class Config {
         .ignoreIfMissing()
         .load()
         .get("GITHUB_TOKEN", "");
+    public static final String HISTORY_URL = Dotenv.configure()
+        .directory("..")
+        .filename("config.env")
+        .ignoreIfMissing()
+        .load()
+        .get("HISTORY_URL", "http://localhost:8021/");
     public static final int PORT = 8021;
     public static final String DIRECTORY_REPOSITORIES = "./repos/";
     public static final String DIRECTORY_BUILD_HISTORY = "./build_history/";

--- a/ci/src/main/java/com/group21/ci/Config.java
+++ b/ci/src/main/java/com/group21/ci/Config.java
@@ -6,6 +6,7 @@ public class Config {
     public static final String GITHUB_TOKEN = Dotenv.configure()
         .directory("..")
         .filename("config.env")
+        .ignoreIfMissing()
         .load()
         .get("GITHUB_TOKEN", "");
     public static final int PORT = 8021;

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -107,8 +107,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 Scanner branchReader = new Scanner(new File(Config.DIRECTORY_BUILD_HISTORY + buildId + "/" + Config.BUILD_BRANCH_FILENAME));
                 Scanner SHAReader = new Scanner(new File(Config.DIRECTORY_BUILD_HISTORY + buildId + "/" + Config.BUILD_IDENTIFIER_FILENAME));
                 Scanner logReader = new Scanner(new File(Config.DIRECTORY_BUILD_HISTORY + buildId + "/" + Config.BUILD_LOG_FILENAME));
-                htmlRespone += "<h2>Branch: " + branchReader.nextLine() + "</h2>";
-                htmlRespone += "<h2>SHA: " + SHAReader.nextLine() + "</h2>";
+                htmlRespone += "<h2>Branch: " + (branchReader.hasNextLine() ? branchReader.nextLine() : "") + "</h2>";
+                htmlRespone += "<h2>SHA: " + (SHAReader.hasNextLine() ? SHAReader.nextLine() : "") + "</h2>";
                 htmlRespone += "<h2>Build log:</h2>";
                 while (logReader.hasNextLine()) {
                     htmlRespone += logReader.nextLine() + "<br>";

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -52,9 +52,9 @@ public class ContinuousIntegrationServer extends AbstractHandler
                 final ExecutorService executor = Executors.newSingleThreadExecutor();
                 executor.execute(new Runnable() {
                     public void run() {
-                        StatusSender statusSender = new StatusSender(repo);
-                        statusSender.sendPendingStatus();
                         RepositoryTester repositoryTester = new RepositoryTester(repo);
+                        StatusSender statusSender = new StatusSender(repo, repositoryTester.getIdentifier());
+                        statusSender.sendPendingStatus();
                         int exitCode = repositoryTester.runTests();
                         if (exitCode == 0) {
                             statusSender.sendSuccessStatus();
@@ -170,8 +170,8 @@ public class ContinuousIntegrationServer extends AbstractHandler
         RepositoryInfo testRepo = new RepositoryInfo(testBranch, testSHA, testCloneUrl, testOwner, testRepositoryName);
         RepositoryTester repositoryTester = new RepositoryTester(testRepo);
         // repositoryTester.runTests();
-        StatusSender ss = new StatusSender(testRepo);
-        // ss.sendSuccessStatus();
+        StatusSender ss = new StatusSender(testRepo, "1707768154560");
+        ss.sendSuccessStatus();
         Server server = new Server(Config.PORT);
         server.setHandler(new ContinuousIntegrationServer()); 
         server.start();

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -40,34 +40,30 @@ public class ContinuousIntegrationServer extends AbstractHandler
         baseRequest.setHandled(true);
         switch (request.getMethod()) {
             case "POST":
-                try{
-                    BufferedReader reader = request.getReader();
-                    RepositoryInfo repo = readPostData(reader);
-                    if (repo == null) {
-                        System.out.println("Unknown POST request");
-                        response.getWriter().println("Unknown POST request, assumed to be ping");
-                        break;
-                    }
-                    String print = "Received commit\nBranch: " + repo.ref + "\nCommit ID: " + repo.commitId + "\nClone URL: " + repo.cloneUrl;
-                    response.getWriter().println(print);
-                    final ExecutorService executor = Executors.newSingleThreadExecutor();
-                    executor.execute(new Runnable() {
-                        public void run() {
-                            StatusSender statusSender = new StatusSender(repo);
-                            statusSender.sendPendingStatus();
-                            RepositoryTester repositoryTester = new RepositoryTester(repo);
-                            int exitCode = repositoryTester.runTests();
-                            if (exitCode == 0) {
-                                statusSender.sendSuccessStatus();
-                            } else {
-                                statusSender.sendFailureStatus();
-                            }
-                        }
-                    });
-
-                } catch (IOException e) {
-                    e.printStackTrace();
+                BufferedReader reader = request.getReader();
+                RepositoryInfo repo = readPostData(reader);
+                if (repo == null) {
+                    System.out.println("Unknown POST request");
+                    response.getWriter().println("Unknown POST request, assumed to be ping");
+                    break;
                 }
+                String print = "Received commit\nBranch: " + repo.ref + "\nCommit ID: " + repo.commitId + "\nClone URL: " + repo.cloneUrl;
+                response.getWriter().println(print);
+                final ExecutorService executor = Executors.newSingleThreadExecutor();
+                executor.execute(new Runnable() {
+                    public void run() {
+                        StatusSender statusSender = new StatusSender(repo);
+                        statusSender.sendPendingStatus();
+                        RepositoryTester repositoryTester = new RepositoryTester(repo);
+                        int exitCode = repositoryTester.runTests();
+                        if (exitCode == 0) {
+                            statusSender.sendSuccessStatus();
+                        } else {
+                            statusSender.sendFailureStatus();
+                        }
+                    }
+                });
+
                 break;
             case "GET":
                 PrintWriter writer = response.getWriter();
@@ -175,7 +171,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         RepositoryTester repositoryTester = new RepositoryTester(testRepo);
         // repositoryTester.runTests();
         StatusSender ss = new StatusSender(testRepo);
-        ss.sendSuccessStatus();
+        // ss.sendSuccessStatus();
         Server server = new Server(Config.PORT);
         server.setHandler(new ContinuousIntegrationServer()); 
         server.start();

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -171,7 +171,7 @@ public class ContinuousIntegrationServer extends AbstractHandler
         RepositoryTester repositoryTester = new RepositoryTester(testRepo);
         // repositoryTester.runTests();
         StatusSender ss = new StatusSender(testRepo, "1707768154560");
-        ss.sendSuccessStatus();
+        // ss.sendSuccessStatus();
         Server server = new Server(Config.PORT);
         server.setHandler(new ContinuousIntegrationServer()); 
         server.start();

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -166,14 +166,16 @@ public class ContinuousIntegrationServer extends AbstractHandler
     // used to start the CI server in command line
     public static void main(String[] args) throws Exception
     {
-        String testOwner = "TRICOT-Hugo";
-        String testRepositoryName = "DD2480-CI-fork-webhook";
-        String testSHA = "20ea9f12c3e043eb50362b0656099023469fece9";
-        String testBranch = "issue/3-status-sender";
-        String testCloneUrl = "https://github.com/TRICOT-Hugo/DD2480-CI-fork-webhook.git";
+        String testOwner = "alexarne";
+        String testRepositoryName = "DD2480-CI";
+        String testSHA = "e9ee1e63e303bbf6f5b010b8fa28d1d71d04fd7a";
+        String testBranch = "issue/37-refactor-status/";
+        String testCloneUrl = "https://github.com/alexarne/DD2480-CI.git";
         RepositoryInfo testRepo = new RepositoryInfo(testBranch, testSHA, testCloneUrl, testOwner, testRepositoryName);
         RepositoryTester repositoryTester = new RepositoryTester(testRepo);
         // repositoryTester.runTests();
+        StatusSender ss = new StatusSender(testRepo);
+        ss.sendSuccessStatus();
         Server server = new Server(Config.PORT);
         server.setHandler(new ContinuousIntegrationServer()); 
         server.start();

--- a/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
+++ b/ci/src/main/java/com/group21/ci/ContinuousIntegrationServer.java
@@ -53,8 +53,15 @@ public class ContinuousIntegrationServer extends AbstractHandler
                     final ExecutorService executor = Executors.newSingleThreadExecutor();
                     executor.execute(new Runnable() {
                         public void run() {
+                            StatusSender statusSender = new StatusSender(repo);
+                            statusSender.sendPendingStatus();
                             RepositoryTester repositoryTester = new RepositoryTester(repo);
-                            repositoryTester.runTests();
+                            int exitCode = repositoryTester.runTests();
+                            if (exitCode == 0) {
+                                statusSender.sendSuccessStatus();
+                            } else {
+                                statusSender.sendFailureStatus();
+                            }
                         }
                     });
 

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -81,7 +81,7 @@ public class RepositoryTester {
                 process.redirectError(Redirect.appendTo(logFile));
                 process.start().waitFor();
                 process.directory(new File(dir));
-                process.command("git", "checkout", branch);
+                process.command("git", "checkout", SHA);
                 process.start().waitFor();
                 process.command("bash",  "test.sh");
                 exitCode = process.start().waitFor();

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -81,6 +81,8 @@ public class RepositoryTester {
                 process.redirectError(Redirect.appendTo(logFile));
                 process.start().waitFor();
                 process.directory(new File(dir));
+                process.command("git", "checkout", branch);
+                process.start().waitFor();
                 process.command("git", "checkout", SHA);
                 process.start().waitFor();
                 process.command("bash",  "test.sh");

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -20,6 +20,7 @@ public class RepositoryTester {
     private String branch;
     private String owner;
     private String repositoryName;
+    private String id;
 
     public RepositoryTester(RepositoryInfo repo) {
         this.owner = repo.owner;
@@ -27,6 +28,15 @@ public class RepositoryTester {
         this.URL = repo.cloneUrl;
         this.SHA = repo.commitId;
         this.branch = repo.ref;
+        this.id = generateUniqueIdentifier();
+    }
+
+    /**
+     * Get the unique identifier for this specific build.
+     * @return The local unique identifier for the build.
+     */
+    public String getIdentifier() {
+        return this.id;
     }
     
     /**
@@ -34,7 +44,6 @@ public class RepositoryTester {
      * @return the exit code from the processes ran
      */
     public int runTests() {
-        String id = generateUniqueIdentifier();
         String dir = Config.DIRECTORY_REPOSITORIES + id;
         File logFile = new File(Config.DIRECTORY_BUILD_HISTORY + id + "/" + Config.BUILD_LOG_FILENAME);
         File SHAFile = new File(Config.DIRECTORY_BUILD_HISTORY + id + "/" + Config.BUILD_IDENTIFIER_FILENAME);

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -60,6 +60,8 @@ public class RepositoryTester {
             logFile.createNewFile();
             SHAFile.createNewFile();
             branchFile.createNewFile();
+            appendToFile(SHA, SHAFile);
+            appendToFile(branch, branchFile);
             if (isWindows){
                 ProcessBuilder process = new ProcessBuilder("cmd", "/c", "git", "clone", URL, dir);
                 process.redirectErrorStream(true);
@@ -117,8 +119,6 @@ public class RepositoryTester {
             e.printStackTrace();
         }
 
-        appendToFile(SHA, SHAFile);
-        appendToFile(branch, branchFile);
         appendToFile(id + ": Exit code " + exitCode, logFile);
         System.out.println(id + ": Exit code " + exitCode);
         cleanFile(logFile);

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -34,8 +34,6 @@ public class RepositoryTester {
      * @return the exit code from the processes ran
      */
     public int runTests() {
-        StatusSender statusSender = new StatusSender(owner, repositoryName, SHA);
-        statusSender.sendPendingStatus();
         String id = generateUniqueIdentifier();
         String dir = Config.DIRECTORY_REPOSITORIES + id;
         File logFile = new File(Config.DIRECTORY_BUILD_HISTORY + id + "/" + Config.BUILD_LOG_FILENAME);
@@ -90,12 +88,6 @@ public class RepositoryTester {
                 // TODO Auto-generated catch block
                 e1.printStackTrace();
             }
-        }
-
-        if (exitCode == 0) {
-            statusSender.sendSuccessStatus();
-        } else {
-            statusSender.sendFailureStatus();
         }
         
         // Delete repo regardless

--- a/ci/src/main/java/com/group21/ci/RepositoryTester.java
+++ b/ci/src/main/java/com/group21/ci/RepositoryTester.java
@@ -83,8 +83,6 @@ public class RepositoryTester {
                 process.directory(new File(dir));
                 process.command("git", "checkout", branch);
                 process.start().waitFor();
-                process.command("git", "checkout", SHA);
-                process.start().waitFor();
                 process.command("bash",  "test.sh");
                 exitCode = process.start().waitFor();
             }

--- a/ci/src/main/java/com/group21/ci/StatusSender.java
+++ b/ci/src/main/java/com/group21/ci/StatusSender.java
@@ -11,13 +11,15 @@ public class StatusSender {
     private String SHA;
     private String statusUrl;
     private HttpClient statusHttpClient;
+    private String buildIdentifier;
     
-    public StatusSender(RepositoryInfo repo) {
+    public StatusSender(RepositoryInfo repo, String id) {
         this.owner = repo.owner;
         this.repositoryName = repo.name;
         this.SHA = repo.commitId;
         statusUrl = getStatusUrl();
         statusHttpClient = HttpClient.newHttpClient();
+        this.buildIdentifier = id;
     }
 
     public void sendErrorStatus() {
@@ -89,6 +91,7 @@ public class StatusSender {
             .POST(HttpRequest.BodyPublishers.ofString("{\"state\":\"" + status + "\"" 
                 + "," + "\"description\":" + "\"" + description + "\""
                 + "," + "\"context\":\"project-continuous-integration-server\""
+                + "," + "\"target_url\":\"" + Config.HISTORY_URL + buildIdentifier + "\""
                 + "}"))
             .build();
             return request;

--- a/ci/src/main/java/com/group21/ci/StatusSender.java
+++ b/ci/src/main/java/com/group21/ci/StatusSender.java
@@ -12,10 +12,10 @@ public class StatusSender {
     private HttpClient statusHttpClient;
     CompletableFuture<HttpResponse<String>> response;
     
-    public StatusSender(String owner, String repositoryName, String SHA) {
-        this.owner = owner;
-        this.repositoryName = repositoryName;
-        this.SHA = SHA;
+    public StatusSender(RepositoryInfo repo) {
+        this.owner = repo.owner;
+        this.repositoryName = repo.name;
+        this.SHA = repo.commitId;
         statusUrl = getStatusUrl();
         statusHttpClient = HttpClient.newHttpClient();
     }

--- a/ci/src/main/java/com/group21/ci/StatusSender.java
+++ b/ci/src/main/java/com/group21/ci/StatusSender.java
@@ -1,5 +1,6 @@
 package com.group21.ci;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.*;
 import java.util.concurrent.CompletableFuture;
@@ -10,7 +11,6 @@ public class StatusSender {
     private String SHA;
     private String statusUrl;
     private HttpClient statusHttpClient;
-    CompletableFuture<HttpResponse<String>> response;
     
     public StatusSender(RepositoryInfo repo) {
         this.owner = repo.owner;
@@ -21,26 +21,55 @@ public class StatusSender {
     }
 
     public void sendErrorStatus() {
-        response = statusHttpClient.sendAsync(requestBuilder("error", 
-                                                "An error occured during the build"),
-                                                HttpResponse.BodyHandlers.ofString());
+        System.out.println("Sent ERROR status");
+        try {
+            HttpResponse<String> response = statusHttpClient.send(
+                requestBuilder("error", "An error occured during the build"),
+                HttpResponse.BodyHandlers.ofString()
+            );
+            System.out.println("Received code: " + response.statusCode());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void sendFailureStatus() {
-        response = statusHttpClient.sendAsync(requestBuilder("failure", 
-                                                "Build has failed"),
-                                                HttpResponse.BodyHandlers.ofString());
+        System.out.println("Sent FAILURE status");
+        try {
+            HttpResponse<String> response = statusHttpClient.send(
+                requestBuilder("failure", "Build has failed"),
+                HttpResponse.BodyHandlers.ofString()
+            );
+            System.out.println("Received code: " + response.statusCode());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void sendPendingStatus() {
-        response = statusHttpClient.sendAsync(requestBuilder("pending", 
-                                                "Build has begun on the CI server"),
-                                                HttpResponse.BodyHandlers.ofString());
+        System.out.println("Sent PENDING status");
+        try {
+            HttpResponse<String> response = statusHttpClient.send(
+                requestBuilder("pending", "Build has begun on the CI server"),
+                HttpResponse.BodyHandlers.ofString()
+            );
+            System.out.println("Received code: " + response.statusCode());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     public void sendSuccessStatus() {
-        response = statusHttpClient.sendAsync(requestBuilder("success", "Build success"), 
-                                                HttpResponse.BodyHandlers.ofString());
+        System.out.println("Sent SUCCESS status");
+        try {
+            HttpResponse<String> response = statusHttpClient.send(
+                requestBuilder("success", "Build success"), 
+                HttpResponse.BodyHandlers.ofString()
+            );
+            System.out.println("Received code: " + response.statusCode());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 

--- a/ci/src/main/java/com/group21/ci/StatusSender.java
+++ b/ci/src/main/java/com/group21/ci/StatusSender.java
@@ -91,7 +91,7 @@ public class StatusSender {
             .POST(HttpRequest.BodyPublishers.ofString("{\"state\":\"" + status + "\"" 
                 + "," + "\"description\":" + "\"" + description + "\""
                 + "," + "\"context\":\"project-continuous-integration-server\""
-                + "," + "\"target_url\":\"" + Config.HISTORY_URL + buildIdentifier + "\""
+                + "," + "\"target_url\":\"" + Config.HISTORY_URL + "/" + buildIdentifier + "\""
                 + "}"))
             .build();
             return request;

--- a/ci/src/test/java/com/group21/ci/StatusSenderTest.java
+++ b/ci/src/test/java/com/group21/ci/StatusSenderTest.java
@@ -13,7 +13,8 @@ public class StatusSenderTest {
 
     @Before
     public void setUp() {
-        sender = new StatusSender("mockOwner", "mockRepo", "mockSha");
+        RepositoryInfo repo = new RepositoryInfo("mockRef", "mockSHA", "mockURL", "mockOwner", "mockRepo");
+        sender = new StatusSender(repo);
     }
 
     /**
@@ -24,7 +25,7 @@ public class StatusSenderTest {
         HttpRequest builtRequest = sender.requestBuilder("status", "description");
 
         HttpRequest expectedRequest = HttpRequest.newBuilder()
-            .uri(URI.create("https://api.github.com/repos/mockOwner/mockRepo/statuses/mockSha"))
+            .uri(URI.create("https://api.github.com/repos/mockOwner/mockRepo/statuses/mockSHA"))
             .header("Authorization", "Bearer " + Config.GITHUB_TOKEN)
             .header("Accept", "application/vnd.github+json")
             .header("X-GitHub-Api-Version", "2022-11-28")

--- a/ci/src/test/java/com/group21/ci/StatusSenderTest.java
+++ b/ci/src/test/java/com/group21/ci/StatusSenderTest.java
@@ -14,7 +14,7 @@ public class StatusSenderTest {
     @Before
     public void setUp() {
         RepositoryInfo repo = new RepositoryInfo("mockRef", "mockSHA", "mockURL", "mockOwner", "mockRepo");
-        sender = new StatusSender(repo);
+        sender = new StatusSender(repo, "mockId");
     }
 
     /**

--- a/config.env
+++ b/config.env
@@ -1,1 +1,0 @@
-GITHUB_TOKEN=


### PR DESCRIPTION
Extracts the status sending from RepositoryTester to the POST request handler, as well as integrating a link in the commit status to the build history.
Closes #37