### PR TITLE
Add javadoc

### DIFF
--- a/ci/pom.xml
+++ b/ci/pom.xml
@@ -124,6 +124,15 @@
               </arguments> -->
           </configuration>
         </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.2</version>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Includes the javadoc plugin.
To generate, do `mvn javadoc:javadoc` and the HTML will be generated under `target/site/apidocs`, and open the `index.html` file
Closes #46